### PR TITLE
Gh-30 Display feature tags in report

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,6 @@
   "cucumberautocomplete.stepsInvariants": true,
   "cucumberautocomplete.onTypeFormat": true,
   "cucumberautocomplete.gherkinDefinitionPart": "(Given|When|Then)\\(",
-  "peacock.color": "#38224c"
+  "peacock.color": "#38224c",
+  "git.enableCommitSigning": true
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # YACHR
-[![Build Status](https://travis-ci.org/yachr/yachr.svg?branch=develop)](https://travis-ci.org/yachr/yachr/branches)
+[![Build Status](https://travis-ci.org/yachr/yachr.svg?branch=GH-30)](https://travis-ci.org/yachr/yachr/branches)
 [![Coverage Status](https://coveralls.io/repos/github/yachr/yachr/badge.svg?branch=develop)](https://coveralls.io/github/yachr/yachr?branch=develop)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 ---

--- a/e2e/features/abilities/user/view-feature-tags.feature
+++ b/e2e/features/abilities/user/view-feature-tags.feature
@@ -1,0 +1,10 @@
+@GH-30
+Ability: View tags in report
+  As a user who makes use of tags
+  I want to see any tags defined in the gherkin present in the report
+
+  @GH-30
+  Scenario: View Feature tag
+    Given Ira has results from a cucumber test containing the tag '@GH-30' against the feature 'View Feature tag'
+    When Ira runs yachr against the result
+    Then Ira will see the tag '@GH-30' in the tile bar of the 'View Feature tag' feature

--- a/e2e/features/abilities/user/view-summary-tags.feature
+++ b/e2e/features/abilities/user/view-summary-tags.feature
@@ -1,0 +1,10 @@
+@GH-30
+Ability: View tags in report
+  As a user who makes use of tags
+  I want to see any tags defined in the gherkin present in the report
+
+  @GH-30
+  Scenario: View Scenario tag
+    Given Jon has results from a cucumber test containing the tag '@GH-30' against the scenario 'View scenario tag'
+    When Jon runs yachr against the result
+    Then Jon will see the tag '@GH-30' in the title bar of the scenario 'View Scenario tag' in the generated report

--- a/e2e/resources/tagsOnScenariosAndFunctions.json
+++ b/e2e/resources/tagsOnScenariosAndFunctions.json
@@ -1,0 +1,391 @@
+[
+  {
+    "description": "  As a user who makes use of tags\n  I want to see any tags defined in the gherkin present in the report",
+    "keyword": "Ability",
+    "name": "View tags in report",
+    "line": 2,
+    "id": "view-tags-in-report",
+    "tags": [
+      {
+        "name": "@GH-30",
+        "line": 1
+      }
+    ],
+    "uri": "e2e\\features\\abilities\\user\\view-feature-tags.feature",
+    "elements": [
+      {
+        "id": "view-tags-in-report;view-feature-tag",
+        "keyword": "Scenario",
+        "line": 7,
+        "name": "View Feature tag",
+        "tags": [
+          {
+            "name": "@GH-30",
+            "line": 1
+          },
+          {
+            "name": "@GH-30",
+            "line": 6
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 8,
+            "name": "Ira has a cucumber result containing the tag '@GH-30' against the feature 'View tags in report'",
+            "match": {
+              "location": "e2e\\step_definitions\\view-feature-tags.steps.js:9"
+            },
+            "result": {
+              "status": "pending",
+              "duration": 1000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 9,
+            "name": "Ira runs yachr against the result",
+            "match": {
+              "location": "e2e\\step_definitions\\view-feature-tags.steps.js:10"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 10,
+            "name": "Ira will see the tag '@GH-30' in the tile bar of the 'View tags in report' feature",
+            "match": {
+              "location": "e2e\\step_definitions\\view-feature-tags.steps.js:11"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "description": "  As a user\n  I would like to see the summary of features and scenarios in my project\n  So that I can gauge my project's health and progress.\n\n  The status of a Scenario behaves like a hierarchy that rolls up.\n  The scenario status will be the 'worst' status of its child steps as follows:\n  ambiguous, failed, undefined, pending, passed\n  Although a step can be skipped, a scneario cannot.\n\n  Ambiguous is the worst because it is similar to a compile erorr. There are\n  two or more implementations that match one step, and the test simply can't be run.\n\n  Failed is next because a step has been implemented, and failed, which is unexpected.\n\n  Undefined is then next, because no implementation has been put together.\n\n  Pending is where the implementation exists, but returns the string pending.\n\n  Finally, if all steps pass, then the scenario passes.",
+    "keyword": "Ability",
+    "name": "View report summary",
+    "line": 1,
+    "id": "view-report-summary",
+    "tags": [],
+    "uri": "e2e\\features\\abilities\\user\\view-report-summary.feature",
+    "elements": [
+      {
+        "id": "view-report-summary;all-passing",
+        "keyword": "Scenario",
+        "line": 23,
+        "name": "All passing",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [
+              {
+                "rows": [
+                  {
+                    "cells": [
+                      "Feature",
+                      "Scenario",
+                      "Step",
+                      "Step Status"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature One",
+                      "Scenario One",
+                      "Step 1",
+                      "passed"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature One",
+                      "Scenario One",
+                      "Step 2",
+                      "passed"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature One",
+                      "Scenario One",
+                      "Step 3",
+                      "passed"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "keyword": "Given ",
+            "line": 24,
+            "name": "a passing scenario",
+            "match": {
+              "location": "e2e\\step_definitions\\view-report-summary.steps.js:48"
+            },
+            "result": {
+              "status": "passed"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 29,
+            "name": "I run yachr against it",
+            "match": {
+              "location": "e2e\\step_definitions\\view-report-summary.steps.js:57"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 50000000
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 30,
+            "name": "a summary showing one passing feature and one passing scenario",
+            "match": {
+              "location": "e2e\\step_definitions\\view-report-summary.steps.js:61"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 31000000
+            }
+          }
+        ]
+      },
+      {
+        "id": "view-report-summary;handle-mixed-states",
+        "keyword": "Scenario",
+        "line": 32,
+        "name": "Handle mixed states",
+        "tags": [],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [
+              {
+                "rows": [
+                  {
+                    "cells": [
+                      "Feature",
+                      "Scenario",
+                      "Step",
+                      "Step Status"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature One",
+                      "Scenario One",
+                      "Step 1",
+                      "passed"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature One",
+                      "Scenario One",
+                      "Step 2",
+                      "ambiguous"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature Two",
+                      "Scenario One",
+                      "Step 1",
+                      "passed"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature Two",
+                      "Scenario One",
+                      "Step 2",
+                      "failed"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature Three",
+                      "Scenario One",
+                      "Step 1",
+                      "passed"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature Three",
+                      "Scenario One",
+                      "Step 2",
+                      "pending"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature Four",
+                      "Scenario One",
+                      "Step 1",
+                      "undefined"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "keyword": "Given ",
+            "line": 33,
+            "name": "the following scenarios",
+            "match": {
+              "location": "e2e\\step_definitions\\view-report-summary.steps.js:54"
+            },
+            "result": {
+              "status": "pending"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 46,
+            "name": "I run yachr against it",
+            "match": {
+              "location": "e2e\\step_definitions\\view-report-summary.steps.js:57"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [
+              {
+                "rows": [
+                  {
+                    "cells": [
+                      "Feature",
+                      "Status"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature One",
+                      "ambiguous"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature Two",
+                      "failed"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature three",
+                      "pending"
+                    ]
+                  },
+                  {
+                    "cells": [
+                      "Feature four",
+                      "undefined"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "keyword": "Then ",
+            "line": 47,
+            "name": "I will see the following in the summary",
+            "match": {
+              "location": "e2e\\step_definitions\\view-report-summary.steps.js:71"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "description": "  As a user who makes use of tags\n  I want to see any tags defined in the gherkin present in the report",
+    "keyword": "Ability",
+    "name": "View tags in report",
+    "line": 2,
+    "id": "view-tags-in-report",
+    "tags": [
+      {
+        "name": "@GH-30",
+        "line": 1
+      }
+    ],
+    "uri": "e2e\\features\\abilities\\user\\view-summary-tags.feature",
+    "elements": [
+      {
+        "id": "view-tags-in-report;view-scenario-tag",
+        "keyword": "Scenario",
+        "line": 7,
+        "name": "View Scenario tag",
+        "tags": [
+          {
+            "name": "@GH-30",
+            "line": 1
+          },
+          {
+            "name": "@GH-30",
+            "line": 6
+          }
+        ],
+        "type": "scenario",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 8,
+            "name": "Jon has a cucumber result containing the tag '@GH-30' against the scenario 'View scenario tag'",
+            "match": {
+              "location": "e2e\\step_definitions\\view-summary-tags.steps.js:9"
+            },
+            "result": {
+              "status": "pending"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 9,
+            "name": "Jon runs yachr against the result",
+            "match": {
+              "location": "e2e\\step_definitions\\view-summary-tags.steps.js:10"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 10,
+            "name": "Jon will see the tag '@GH-30' in the title bar of the scenario 'View Scenario tag' in the generated report",
+            "match": {
+              "location": "e2e\\step_definitions\\view-summary-tags.steps.js:11"
+            },
+            "result": {
+              "status": "skipped"
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/e2e/step_definitions/view-feature-tags.steps.ts
+++ b/e2e/step_definitions/view-feature-tags.steps.ts
@@ -1,0 +1,35 @@
+// tslint:disable-next-line: file-name-casing
+import { expect } from 'chai';
+import * as cherrio from 'cheerio';
+import { Given, Then, When } from 'cucumber';
+import * as fs from 'fs';
+import { IReportOptions } from '../../dist/src/models/reportOptions';
+
+import { Reporter } from '../../dist/src/reporter';
+const reportLocation = 'e2e/reportOutput/report-feature-tags.html';
+const jsonOutput = 'e2e/resources/tagsOnScenariosAndFunctions.json';
+
+let reporter: Reporter;
+let reportOptions: IReportOptions;
+
+// tslint:disable-next-line: max-line-length
+Given(`Ira has results from a cucumber test containing the tag '@GH-30' against the feature 'View Feature tag'`, () => {
+  reportOptions = <IReportOptions> {
+    jsonFile: jsonOutput,
+    output: reportLocation,
+  };
+});
+
+When(`Ira runs yachr against the result`, () => {
+  reporter = new Reporter();
+  reporter.generate(reportOptions);
+});
+
+Then(`Ira will see the tag '@GH-30' in the tile bar of the 'View Feature tag' feature`, () => {
+  const $ = cherrio.load(fs.readFileSync(reportLocation, 'utf8'));
+  const pageText = $('html').text();
+
+  // ([.\n\s]*)1/ Match all spaces and new line chars
+  const passedFeatures = /@GH-30/;
+  expect(passedFeatures.test(pageText)).eql(true);
+});

--- a/e2e/step_definitions/view-summary-tags.steps.ts
+++ b/e2e/step_definitions/view-summary-tags.steps.ts
@@ -1,0 +1,9 @@
+import { Given, Then, When } from 'cucumber';
+
+// tslint:disable-next-line: max-line-length
+Given(`Jon has results from a cucumber test containing the tag '@GH-30' against the scenario 'View scenario tag'`, () => 'pending');
+
+When(`Jon runs yachr against the result`, () => 'pending');
+
+Then(`Jon will see the tag '@GH-30' in the title bar of the scenario 'View Scenario tag' in the generated report`, () =>
+  'pending');

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
       ".ts"
     ],
     "exclude": [
+      "e2e/*",
       "**/*.d.ts",
       "**/*.spec.ts",
       "dist/*",

--- a/src/models/aggregator/featureSummary.ts
+++ b/src/models/aggregator/featureSummary.ts
@@ -9,13 +9,16 @@ export class FeatureSummary {
 
   public featureName: string = '';
   public featureDescription: string = '';
-  public featureKeyword: string = ''; // Ability / Feature
+  public featureKeyword: string = ''; // Ability | Feature
 
   public passingScenarios: ScenarioSummary[] = [];
   public failingScenarios: ScenarioSummary[] = [];
   public ambiguousScenarios: ScenarioSummary[] = [];
   public pendingScenarios: ScenarioSummary[] = [];
   public undefinedScenarios: ScenarioSummary[] = [];
+
+  /** Comma separated string of all tags on the feature */
+  public tags: string = '';
 
   /** The total number of Scenarios that are ambiguously defined for the Feature */
   public get ambiguous(): number { return this.ambiguousScenarios.length; }

--- a/src/reportAggregator.ts
+++ b/src/reportAggregator.ts
@@ -35,6 +35,7 @@ export class ReportAggregator {
       // for this given feature
       const featureSummary = this.getSummaryForFeature(feature);
 
+      featureSummary.tags = feature.tags.map((tag => tag.name)).join(', ');
       featureSuiteSummary.aggregateFeature(featureSummary);
       scenarioSuiteSummary.aggregateFeature(featureSummary);
     });

--- a/src/templates/feature.html
+++ b/src/templates/feature.html
@@ -1,6 +1,9 @@
 <details class="{{ getFeatureCss this}}">
   <summary>
-    {{this.featureKeyword}}: {{this.featureName}}
+    {{#if this.tags }}
+    <div><strong><small>{{ this.tags }}</small></strong></div>
+    {{/if}}
+    <span>{{this.featureKeyword}}: {{this.featureName}}</span>
     <span class="feature-rollup-summary">
       {{#if this.failingScenarios.length}}
       <i class="material-icons" title="Failing">clear</i>{{this.failingScenarios.length}}
@@ -20,22 +23,22 @@
     </span>
   </summary>
   <section>
-  <p class="feature-description">
-{{this.featureDescription}}</p>
+    <p class="feature-description">
+      {{this.featureDescription}}</p>
     {{#each this.failingScenarios}}
-      {{> scenario}}
+    {{> scenario}}
     {{/each}}
     {{#each this.undefinedScenarios}}
-      {{> scenario}}
+    {{> scenario}}
     {{/each}}
     {{#each this.ambiguousScenarios}}
-      {{> scenario}}
+    {{> scenario}}
     {{/each}}
     {{#each this.pendingScenarios}}
-      {{> scenario}}
+    {{> scenario}}
     {{/each}}
     {{#each this.passingScenarios}}
-      {{> scenario}}
+    {{> scenario}}
     {{/each}}
   </section>
 </details>

--- a/src/templates/standard.html
+++ b/src/templates/standard.html
@@ -4,7 +4,7 @@
 <head>
   <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <style>
     body {
       font-family: 'Roboto', sans-serif;
@@ -13,6 +13,18 @@
     summary {
       background-color: rgb(235, 231, 231);
       padding: 10px
+    }
+
+    details>summary {
+      list-style: none;
+    }
+
+    details summary::-webkit-details-marker {
+      display: none;
+    }
+
+    details summary::-moz-list-bullet {
+      display: none;
     }
 
     .chart {
@@ -60,7 +72,7 @@
     }
 
     details .feature-description {
-      white-space:pre-wrap;
+      white-space: pre-wrap;
     }
 
     .scenario details p:hover {
@@ -75,7 +87,7 @@
       border: 1px solid rgba(75, 192, 192, 1)
     }
 
-    .passing-feature > summary {
+    .passing-feature>summary {
       background-color: rgba(75, 192, 192, 0.2)
     }
 
@@ -83,7 +95,7 @@
       border: 1px solid rgba(75, 192, 192, 1)
     }
 
-    .passing-scenario > summary {
+    .passing-scenario>summary {
       background-color: rgba(75, 192, 192, 0.2)
     }
 
@@ -103,7 +115,7 @@
       border: 1px solid rgb(255, 99, 132, 1)
     }
 
-    .failing-feature > summary {
+    .failing-feature>summary {
       background-color: rgba(255, 99, 132, 0.2)
     }
 
@@ -111,7 +123,7 @@
       border: 1px solid rgb(255, 99, 132, 1)
     }
 
-    .failing-scenario > summary {
+    .failing-scenario>summary {
       background-color: rgba(255, 99, 132, 0.2)
     }
 
@@ -124,7 +136,7 @@
       border: 1px solid rgb(255, 140, 0, 1)
     }
 
-    .ambiguous-feature > summary {
+    .ambiguous-feature>summary {
       background-color: rgba(255, 140, 0, 0.2)
     }
 
@@ -132,7 +144,7 @@
       border: 1px solid rgb(255, 140, 0, 1)
     }
 
-    .ambiguous-scenario > summary {
+    .ambiguous-scenario>summary {
       background-color: rgba(255, 140, 0, 0.2)
     }
 
@@ -145,7 +157,7 @@
       border: 1px solid rgb(54, 162, 235, 1)
     }
 
-    .undefined-feature > summary {
+    .undefined-feature>summary {
       background-color: rgba(54, 162, 235, 0.2)
     }
 
@@ -153,7 +165,7 @@
       border: 1px solid rgb(54, 162, 235, 1)
     }
 
-    .undefined-scenario > summary {
+    .undefined-scenario>summary {
       background-color: rgba(54, 162, 235, 0.2)
     }
 
@@ -166,7 +178,7 @@
       border: 1px solid rgba(111, 109, 107, 1);
     }
 
-    .pending-feature > summary {
+    .pending-feature>summary {
       background-color: rgba(111, 109, 107, 0.2);
     }
 
@@ -174,7 +186,7 @@
       border: 1px solid rgba(111, 109, 107, 1);
     }
 
-    .pending-scenario > summary {
+    .pending-scenario>summary {
       background-color: rgba(111, 109, 107, 0.2);
     }
 
@@ -187,7 +199,8 @@
 
 <body style="width: 1280px; margin: auto;">
   <h1>Specification Execution Results</h1>
-  <span style="position: absolute;right: 40px;top: 15px; font-size: 12px; color: lightgray;">Generated at: {{ generateTime }}</span>
+  <span style="position: absolute;right: 40px;top: 15px; font-size: 12px; color: lightgray;">Generated at:
+    {{ generateTime }}</span>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
 
   <div class="chart">
@@ -207,49 +220,49 @@
         labels: ['Failed', 'Undefined', 'Pending', 'Passed', 'Ambiguous'],
         datasets: [{
           data: [
-          {{ cucumberReportSummary.featureSummary.failed }},
-          {{ featureUndef cucumberReportSummary.featureSummary }},
+            {{ cucumberReportSummary.featureSummary.failed }},
+        {{ featureUndef cucumberReportSummary.featureSummary }},
           {{ cucumberReportSummary.featureSummary.pending }},
-          {{ cucumberReportSummary.featureSummary.passed }},
-          {{ cucumberReportSummary.featureSummary.ambiguous }},
+    { { cucumberReportSummary.featureSummary.passed } },
+    { { cucumberReportSummary.featureSummary.ambiguous } },
         ],
-        backgroundColor: [
-          'rgba(255, 99, 132, 0.2)',
-          'rgba(54, 162, 235, 0.2)',
-          'rgba(111, 109, 107, 0.2)',
-          'rgba(75, 192, 192, 0.2)',
-          'rgba(255, 140, 0, 0.2)',
-        ],
-        borderColor: [
-          'rgba(255, 99, 132, 1)',
-          'rgba(54, 162, 235, 1)',
-          'rgba(111, 109, 107, 1)',
-          'rgba(75, 192, 192, 1)',
-          'rgba(255, 140, 0, 1)',
-        ],
+    backgroundColor: [
+      'rgba(255, 99, 132, 0.2)',
+      'rgba(54, 162, 235, 0.2)',
+      'rgba(111, 109, 107, 0.2)',
+      'rgba(75, 192, 192, 0.2)',
+      'rgba(255, 140, 0, 0.2)',
+    ],
+      borderColor: [
+        'rgba(255, 99, 132, 1)',
+        'rgba(54, 162, 235, 1)',
+        'rgba(111, 109, 107, 1)',
+        'rgba(75, 192, 192, 1)',
+        'rgba(255, 140, 0, 1)',
+      ],
         borderWidth: 1
       }]
     },
-      options: {
-        responsive: true,
+    options: {
+      responsive: true,
         legend: {
-          display: false
-        },
-        title: {
-          display: true,
+        display: false
+      },
+      title: {
+        display: true,
           text: "Feature Summary ({{cucumberReportSummary.featureSummary.total}} Total)",
-          fontSize: 24
-        },
-        scales: {
-          yAxes: [{
-            ticks: {
-              precision: 0,
-              fixedStepSize: 1,
-              beginAtZero: true
-            }
-          }]
-        }
+            fontSize: 24
+      },
+      scales: {
+        yAxes: [{
+          ticks: {
+            precision: 0,
+            fixedStepSize: 1,
+            beginAtZero: true
+          }
+        }]
       }
+    }
     });
 
     var ctx2 = document.getElementById('myChart2').getContext('2d');
@@ -262,52 +275,52 @@
         datasets: [{
           data: [
             {{ cucumberReportSummary.scenarioSummary.failed }},
-            {{ scenarioUndef cucumberReportSummary.scenarioSummary }},
+        {{ scenarioUndef cucumberReportSummary.scenarioSummary }},
             {{ cucumberReportSummary.scenarioSummary.pending }},
-            {{ cucumberReportSummary.scenarioSummary.passed }},
-            {{ cucumberReportSummary.scenarioSummary.ambiguous }},
+    { { cucumberReportSummary.scenarioSummary.passed } },
+    { { cucumberReportSummary.scenarioSummary.ambiguous } },
           ],
-          backgroundColor: [
-            'rgba(255, 99, 132, 0.2)',
-            'rgba(54, 162, 235, 0.2)',
-            'rgba(111, 109, 107, 0.2)',
-            'rgba(75, 192, 192, 0.2)',
-            'rgba(255, 140, 0, 0.2)',
+    backgroundColor: [
+      'rgba(255, 99, 132, 0.2)',
+      'rgba(54, 162, 235, 0.2)',
+      'rgba(111, 109, 107, 0.2)',
+      'rgba(75, 192, 192, 0.2)',
+      'rgba(255, 140, 0, 0.2)',
 
-            // 'rgba(255, 159, 64, 0.2)'
-          ],
-          borderColor: [
-            'rgba(255, 99, 132, 1)',
-            'rgba(54, 162, 235, 1)',
-            'rgba(111, 109, 107, 1)',
-            'rgba(75, 192, 192, 1)',
-            'rgba(255, 140, 0, 1)',
-            // 'rgba(153, 102, 255, 1)',
-            // 'rgba(255, 159, 64, 1)'
-          ],
-          borderWidth: 1
+      // 'rgba(255, 159, 64, 0.2)'
+    ],
+      borderColor: [
+        'rgba(255, 99, 132, 1)',
+        'rgba(54, 162, 235, 1)',
+        'rgba(111, 109, 107, 1)',
+        'rgba(75, 192, 192, 1)',
+        'rgba(255, 140, 0, 1)',
+        // 'rgba(153, 102, 255, 1)',
+        // 'rgba(255, 159, 64, 1)'
+      ],
+        borderWidth: 1
         }]
       },
-      options: {
-        responsive: true,
+    options: {
+      responsive: true,
         legend: {
-          display: false
-        },
-        title: {
-          display: true,
+        display: false
+      },
+      title: {
+        display: true,
           text: "Scenario Summary ({{cucumberReportSummary.scenarioSummary.total}} Total)",
-          fontSize: 24
-        },
-        scales: {
-          yAxes: [{
-            ticks: {
-              precision: 0,
-              fixedStepSize: 1,
-              beginAtZero: true
-            }
-          }]
-        }
+            fontSize: 24
+      },
+      scales: {
+        yAxes: [{
+          ticks: {
+            precision: 0,
+            fixedStepSize: 1,
+            beginAtZero: true
+          }
+        }]
       }
+    }
     });
   </script>
 
@@ -353,36 +366,6 @@
 
   <div>
     <h2>Feature Breakdown</h2>
-
-    {{#each cucumberReportSummary.featureSummary.failingFeatures}}
-    {{> feature}}
-    <!-- <details class="{{ getFeatureCss this}}">
-        <summary>
-          Ability: {{this.featureName}}
-          <span class="feature-rollup-summary">
-          <i class="material-icons">done</i>{{this.passingScenarios.length}}</span>
-        </summary>
-        <section>
-          <p class="feature-description"
-          >{{this.featureDescription}}</p>
-
-          {{#each this.passingScenarios}}
-          <details>
-            <summary>
-              Scenario: {{this.scenarioName}} <span class="feature-rollup-summary">
-                <i class="material-icons">done</i>{{this.passed}}</span>
-            </summary>
-            test here
-            {{#each this.steps}}
-            <p title="Passing"><strong class="passing-step step">{{this.keyword}}</strong>
-            {{ this.name }}
-            </p>
-            {{/each}}
-          </details>
-          {{/each}}
-        </section>
-    </details> -->
-    {{/each}}
 
     {{#each cucumberReportSummary.featureSummary.ambiguousFeatures}}
     {{> feature}}


### PR DESCRIPTION
Concatinates the features from the json output into a comma separated string. This is then displayed in the summary of the features detail block.

The summary/feature arrow renders on the bottom line when there is two lines to display, so I turned these off. I think it looks cleaner, we can look at adding it back if its a problem.