### PR TITLE
GH-30 Display tags on Summary elements

### DIFF
--- a/e2e/step_definitions/view-feature-tags.steps.ts
+++ b/e2e/step_definitions/view-feature-tags.steps.ts
@@ -30,6 +30,6 @@ Then(`Ira will see the tag '@GH-30' in the tile bar of the 'View Feature tag' fe
   const pageText = $('html').text();
 
   // ([.\n\s]*)1/ Match all spaces and new line chars
-  const passedFeatures = /@GH-30/;
+  const passedFeatures = /@GH-30([.\n\s]*)Ability: View tags in report/;
   expect(passedFeatures.test(pageText)).eql(true);
 });

--- a/e2e/step_definitions/view-summary-tags.steps.ts
+++ b/e2e/step_definitions/view-summary-tags.steps.ts
@@ -1,9 +1,35 @@
+// tslint:disable-next-line: file-name-casing
+import { expect } from 'chai';
+import * as cherrio from 'cheerio';
 import { Given, Then, When } from 'cucumber';
+import * as fs from 'fs';
+import { IReportOptions } from '../../dist/src/models/reportOptions';
+
+import { Reporter } from '../../dist/src/reporter';
+const reportLocation = 'e2e/reportOutput/report-summary-tags.html';
+const jsonOutput = 'e2e/resources/tagsOnScenariosAndFunctions.json';
+
+let reporter: Reporter;
+let reportOptions: IReportOptions;
+// tslint:disable-next-line: max-line-length
+Given(`Jon has results from a cucumber test containing the tag '@GH-30' against the scenario 'View scenario tag'`, () => {
+  reportOptions = <IReportOptions>{
+    jsonFile: jsonOutput,
+    output: reportLocation,
+  };
+});
+
+When(`Jon runs yachr against the result`, () => {
+  reporter = new Reporter();
+  reporter.generate(reportOptions);
+});
 
 // tslint:disable-next-line: max-line-length
-Given(`Jon has results from a cucumber test containing the tag '@GH-30' against the scenario 'View scenario tag'`, () => 'pending');
+Then(`Jon will see the tag '@GH-30' in the title bar of the scenario 'View Scenario tag' in the generated report`, () => {
+  const $ = cherrio.load(fs.readFileSync(reportLocation, 'utf8'));
+  const pageText = $('html').text();
 
-When(`Jon runs yachr against the result`, () => 'pending');
-
-Then(`Jon will see the tag '@GH-30' in the title bar of the scenario 'View Scenario tag' in the generated report`, () =>
-  'pending');
+  // ([.\n\s]*)1/ Match all spaces and new line chars
+  const passedFeatures = /@GH-30([.\n\s]*)Scenario: View Feature tag/;
+  expect(passedFeatures.test(pageText)).eql(true);
+});

--- a/src/models/aggregator/scenarioSummary.ts
+++ b/src/models/aggregator/scenarioSummary.ts
@@ -36,6 +36,9 @@ export class ScenarioSummary {
   public scenarioDescription: string = '';
   public scenarioKeyword: string = '';
 
+  /** All tags on the scenario as a comma separated list */
+  public tags: string = '';
+
   /** All steps in the scenario */
   get total(): number {
     return this.passed + this.failed + this.undefined +

--- a/src/reportAggregator.spec.ts
+++ b/src/reportAggregator.spec.ts
@@ -68,6 +68,7 @@ describe('report-aggregator', () => {
       scenarioName: 'Login via login page',
       skipped: 0,
       steps,
+      tags: '',
       totalDuration: 5,
       undefined: 0
     } as ScenarioSummary;
@@ -260,6 +261,7 @@ describe('report-aggregator', () => {
       scenarioName: 'Login via login page',
       skipped: 1,
       steps,
+      tags: '',
       totalDuration: 40,
       undefined: 0,
     };

--- a/src/reportAggregator.ts
+++ b/src/reportAggregator.ts
@@ -92,8 +92,8 @@ export class ReportAggregator {
     summary.scenarioName = scenario.name;
     summary.scenarioDescription = scenario.description || '';
     summary.scenarioKeyword = scenario.keyword;
+    summary.tags = scenario.tags.map((tag => tag.name)).join(', ');
 
     return summary;
   }
-
 }

--- a/src/reporter.manual.spec.ts
+++ b/src/reporter.manual.spec.ts
@@ -5,7 +5,7 @@
 // import { IReportOptions } from './models/reportOptions';
 // import { Reporter } from './reporter';
 
-// describe('reporter manual', () => {
+// describe.only('reporter manual', () => {
 //   let reporter: Reporter;
 //   beforeEach(() => {
 //     reporter = new Reporter();

--- a/src/templates/scenario.html
+++ b/src/templates/scenario.html
@@ -1,6 +1,9 @@
 <details class="{{getScenarioCss this}}">
   <summary>
-    Scenario: {{this.scenarioName}}
+    {{#if this.tags }}
+    <div><strong><small>{{ this.tags }}</small></strong></div>
+    {{/if}}
+    {{this.scenarioKeyword}}: {{this.scenarioName}}
     <span class="feature-rollup-summary">
       {{#if this.failed}}
       <i class="material-icons" title="Failing">clear</i>{{this.failed}}


### PR DESCRIPTION
Displays the tags for the summary in the report
Makes the the 'Summary' keyword is now taken from the report instead if being hard coded to Summary.
